### PR TITLE
Update upstream branch name for lsl

### DIFF
--- a/Formula/lsl.rb
+++ b/Formula/lsl.rb
@@ -2,13 +2,13 @@
 class Lsl < Formula
   desc "Library for multi-modal time-synched data transmission over the network"
   homepage "https://labstreaminglayer.readthedocs.io/"
-  url "https://github.com/sccn/liblsl", using: :git
+  url "https://github.com/sccn/liblsl", using: :git, branch: "main"
   version "1.16.2"
   sha256 "923aa4c81c0fef651c325e3c27aa5b96771540ca2a0933d1b327db27c6dac839"
   license "MIT"
   # NOTE: use `openssl dgst -sha256 <targ.gz file downloaded from release>` to get sha256
 
-  head "https://github.com/sccn/liblsl.git"
+  head "https://github.com/sccn/liblsl.git", branch: "main"
 
   # To make a bottle:
   # 1 - `brew install --build-bottle lsl`


### PR DESCRIPTION
As of this week, trying to install `lsl` via `brew install labstreaminglayer/tap/lsl` results in the following error:

```
 ==> Tapping labstreaminglayer/tap
Cloning into '/usr/local/Homebrew/Library/Taps/labstreaminglayer/homebrew-tap'...
Tapped 2 formulae (18 files, 34.9KB).
==> Fetching dependencies for labstreaminglayer/tap/lsl: cmake
==> Fetching cmake
==> Downloading https://ghcr.io/v2/homebrew/core/cmake/manifests/4.0.3
==> Downloading https://ghcr.io/v2/homebrew/core/cmake/blobs/sha256:dc93b4885174dc8c41727e97a3e3ef1429d74e66c8923d450f3edf04d9564055
==> Fetching labstreaminglayer/tap/lsl
==> Cloning https://github.com/sccn/liblsl
Cloning into '/Users/runner/Library/Caches/Homebrew/lsl--git'...
fatal: Remote branch master not found in upstream origin
Error: lsl: Failed to download resource "lsl"
Failure while executing; `/usr/bin/env git clone --branch master --config advice.detachedHead=false --config core.fsmonitor=false https://github.com/sccn/liblsl /Users/runner/Library/Caches/Homebrew/lsl--git` exited with 128. Here's the output:
Cloning into '/Users/runner/Library/Caches/Homebrew/lsl--git'...
fatal: Remote branch master not found in upstream origin



==> Installing lsl from labstreaminglayer/tap
==> Installing dependencies for labstreaminglayer/tap/lsl: cmake
==> Installing labstreaminglayer/tap/lsl dependency: cmake
==> Downloading https://ghcr.io/v2/homebrew/core/cmake/manifests/4.0.3
Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/f12ede4a1167d594911901094e755e81dc1f0673c871f889b6a3ef15469dff5d--cmake-4.0.3.bottle_manifest.json
==> Pouring cmake--4.0.3.ventura.bottle.tar.gz
🍺  /usr/local/Cellar/cmake/4.0.3: 3,870 files, 62.2MB
==> Installing labstreaminglayer/tap/lsl
==> Cloning https://github.com/sccn/liblsl
Cloning into '/Users/runner/Library/Caches/Homebrew/lsl--git'...
fatal: Remote branch master not found in upstream origin
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "lsl"
Failure while executing; `/usr/bin/env git clone --branch master --config advice.detachedHead=false --config core.fsmonitor=false https://github.com/sccn/liblsl /Users/runner/Library/Caches/Homebrew/lsl--git` exited with 128. Here's the output:
Cloning into '/Users/runner/Library/Caches/Homebrew/lsl--git'...
fatal: Remote branch master not found in upstream origin
```

Looking at https://github.com/sccn/liblsl.git, it seems that the `master` branch is gone, and there is `main` instead (in addition to `dev`).

Have the `lsl.rb` Formula explicitly specify the branch to use (i.e., `master`).